### PR TITLE
Dedicated Video Card

### DIFF
--- a/Walgelijk.OpenTK/Graphics/OpenTKWindow.cs
+++ b/Walgelijk.OpenTK/Graphics/OpenTKWindow.cs
@@ -170,6 +170,7 @@ public class OpenTKWindow : Window
 
     public OpenTKWindow(string title, Vector2 position, Vector2 size)
     {
+        InitializeDedicatedGraphics();
         window = new NativeWindow(new NativeWindowSettings
         {
             Size = new global::OpenTK.Mathematics.Vector2i((int)size.X, (int)size.Y),
@@ -198,6 +199,28 @@ public class OpenTKWindow : Window
         internalGraphics = new OpenTKGraphics();
     }
 
+    [DllImport("nvapi64.dll", EntryPoint = "fake")]
+    private static extern int LoadNvApi64();
+
+    [DllImport("nvapi.dll", EntryPoint = "fake")]
+    private static extern int LoadNvApi32();
+
+    /// <summary>
+    /// Sets the default video card to Nvidia instead of the low-end Intel GPU for laptops with multiple GPUs.
+    /// This can be overridden per app in the Windows graphics menu.
+    /// </summary>
+    private static void InitializeDedicatedGraphics()
+    {
+        try
+        {
+            if (Environment.Is64BitProcess) 
+                LoadNvApi64();
+            else
+                LoadNvApi32();
+        }
+        catch { } // will always fail since 'fake' entry point doesn't exist
+    }
+    
     public override void Close() => window.Close();
 
     public override void ResetInputState() => inputHandler.Reset();


### PR DESCRIPTION
Initialize the Nvidia API so that the dedicated Nvidia card is used instead of the low-end Intel (Arc) GPU on laptops with multiple GPUs (most Windows gaming laptops), as this is the expected behaviour for games on these devices.

With my awesome code running MIR:
![image](https://github.com/user-attachments/assets/536b9acb-7c4b-4df8-b98b-86a58ddecec0)

Without:
![image](https://github.com/user-attachments/assets/ef92ce4e-cb74-4f30-9860-95dc5d02c578)

Note: The chosen GPU can still be overridden through the Windows graphics settings per app and will work. This just sets the 'Let Windows decide' option to the dedicated card by default.

btw, it's really annoying that I need to fix an issue in MIR in Walgelijk with no easy way to test the fix due to the use of the Walgelijk NuGet package. Having a single solution with direct Walgelijk project references would be much better e.g. Nurose.