### PR TITLE
Small Linux crash fixes

### DIFF
--- a/Walgelijk/System/Debugging/ConsoleSessionHistory.cs
+++ b/Walgelijk/System/Debugging/ConsoleSessionHistory.cs
@@ -28,7 +28,7 @@ public sealed class ConsoleSessionHistory
     public ConsoleSessionHistory()
     {
         buffer = new string[BufferSize];
-        var fullPath = new StringBuilder(Directory.GetCurrentDirectory()).Append(Path.DirectorySeparatorChar).Append(FilePath).ToString();
+        var fullPath = Path.Combine(Game.Main.AppDataDirectory, FilePath);
 
         if (File.Exists(fullPath))
         {

--- a/Walgelijk/Window/Window.cs
+++ b/Walgelijk/Window/Window.cs
@@ -217,6 +217,8 @@ public abstract class Window
     /// <param name="heightPadding">How many pixels away from the bottom edge of the screen the cursor is locked to.</param>
     protected void ConfineCursor(int leftPadding = 0, int topPadding = 0, int widthPadding = 0, int heightPadding = 0)
     {
+        if(!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
+
         var windowRECT = new RECT { Left = (int)Position.X - leftPadding, Top = (int)Position.Y - topPadding, Bottom = Height - heightPadding, Right = Width - widthPadding };
         ClipCursor(ref windowRECT);
     }


### PR DESCRIPTION
- Write `console_session.txt` to the app data directory instead of the current directory (prevents crash on exit if directory's write protected).
- Don't ever attempt to clip cursor when not on Windows (prevents crash when going fullscreen, clipping cursor relies on an `user32.dll` method, we don't have that). Game seems to work fine on Wayland without cursor clipping.